### PR TITLE
Configure GitHub Pages deployment with Jekyll

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Build and Deploy Jekyll site
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Build with Jekyll
+        env:
+          JEKYLL_ENV: production
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "github-pages", group: :jekyll_plugins

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+# Jekyll configuration for the Countdown web app site
+name: Countdown Web App
+url: ""  # Set by GitHub Pages deployment
+baseurl: ""
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor
+  - README.md

--- a/index.html
+++ b/index.html
@@ -1,11 +1,19 @@
+---
+layout: null
+permalink: /
+---
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
+    <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url=dual_project_time_visualization_clock_calendar.html">
-    <title>Redirecting...</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Countdown Visualization Redirect</title>
   </head>
   <body>
-    <!-- Optional: Add a message for users with older browsers or those who prefer not to be automatically redirected. -->
-    <p>If you are not redirected, <a href="dual_project_time_visualization_clock_calendar.html">click here</a>.</p>
+    <main>
+      <h1>Redirecting to the Countdown Visualization</h1>
+      <p>If your browser does not automatically redirect you, please <a href="dual_project_time_visualization_clock_calendar.html">click here to open the interactive clock and calendar view</a>.</p>
+    </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a Jekyll configuration and GitHub Pages workflow to build and deploy the site via Actions
- configure the index page to redirect visitors to the countdown visualization with accessible messaging

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68e4963619d883319ba3b69461b7a5b6